### PR TITLE
Update output path for 1.6 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This mod adds new utility-based columns to RimWorld. These have a wide range of 
 2. Copy the `UtilityColumns` folder into your RimWorld `Mods` directory.
 3. Enable **Utility Columns** from the in-game mod menu and restart the game.
 4. For RimWorld **1.6**, compile the assembly using the files in the `Source`
-   folder, as the prebuilt DLL isn't included here.
+   folder and output it to the `1.6/Assemblies` directory, as the prebuilt
+   DLL isn't included here.
 
 ## Compatibility
 - **Supported RimWorld versions:** 1.2, 1.3, 1.4, 1.5 and 1.6.

--- a/Source/RimWorldColumns/RimWorldColumns/RimWorldColumns.csproj
+++ b/Source/RimWorldColumns/RimWorldColumns/RimWorldColumns.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latestmajor</LangVersion>
-    <OutputPath>..\..\..\Assemblies\</OutputPath>
+    <OutputPath>..\..\..\1.6\Assemblies\</OutputPath>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update RimWorldColumns.csproj output path to use the 1.6 Assemblies folder
- clarify README instructions for building RimWorld 1.6 assembly

## Testing
- `dotnet build RimWorldColumns.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601471a7a0832fa36cd0c29f71d7a3