### PR TITLE
Fix output path for 1.6 build

### DIFF
--- a/Source/RimWorldColumns/RimWorldColumns/RimWorldColumns.csproj
+++ b/Source/RimWorldColumns/RimWorldColumns/RimWorldColumns.csproj
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latestmajor</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>..\..\..\1.6\Assemblies\</OutputPath>
   </PropertyGroup>
   


### PR DESCRIPTION
## Summary
- ensure RimWorldColumns.csproj puts build output directly into `1.6/Assemblies`
  without the extra `net472` folder

## Testing
- `dotnet build RimWorldColumns.csproj -c Debug` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601b787b60832fadbd4290246c7c1b