### PR TITLE
Handle low-ammo turrets as non-threats

### DIFF
--- a/1.5/Defs/Buildings/Structure.xml
+++ b/1.5/Defs/Buildings/Structure.xml
@@ -517,7 +517,7 @@
 		<defName>DetColumnMod</defName>
 		<label>cluster column</label>
 		<description>A column for base defense. Upon detecting an enemy in any direction, it will detonate a highly explosive cluster charge into the same direction. Can be reloaded.</description>
-		<thingClass>Building_TurretGun</thingClass>
+                <thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>
@@ -681,7 +681,7 @@
 		<defName>FlameColumnMod</defName>
 		<label>flame column</label>
 		<description>A column for base defense. Upon detecting an enemy in any direction, it will detonate an incendiary bomb charge into the same direction. Can be reloaded.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>
@@ -850,7 +850,7 @@
 		<defName>EMPColumnMod</defName>
 		<label>stun pulse column</label>
 		<description>An advanced column for base defense. Upon detecting an enemy in any direction, it will emits a strong stun pulse into the same direction. Enemies within range are stunned for 15 seconds. Can be reloaded.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>
@@ -1016,7 +1016,7 @@
 		<defName>DeadColumnMod</defName>
 		<label>Deadlife column</label>
 		<description>An advanced column for base defense. Upon detecting an enemy in any direction, it will raise nearby human and animal corpses as shamblers. The shamblers will only attack your enemies.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>

--- a/1.6/Defs/Buildings/Structure.xml
+++ b/1.6/Defs/Buildings/Structure.xml
@@ -517,7 +517,7 @@
 		<defName>DetColumnMod</defName>
 		<label>cluster column</label>
 		<description>A column for base defense. Upon detecting an enemy in any direction, it will detonate a highly explosive cluster charge into the same direction. Can be reloaded.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>
@@ -681,7 +681,7 @@
 		<defName>FlameColumnMod</defName>
 		<label>flame column</label>
 		<description>A column for base defense. Upon detecting an enemy in any direction, it will detonate an incendiary bomb charge into the same direction. Can be reloaded.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>
@@ -850,7 +850,7 @@
 		<defName>EMPColumnMod</defName>
 		<label>stun pulse column</label>
 		<description>An advanced column for base defense. Upon detecting an enemy in any direction, it will emits a strong stun pulse into the same direction. Enemies within range are stunned for 15 seconds. Can be reloaded.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>
@@ -1016,7 +1016,7 @@
 		<defName>DeadColumnMod</defName>
 		<label>Deadlife column</label>
 		<description>An advanced column for base defense. Upon detecting an enemy in any direction, it will raise nearby human and animal corpses as shamblers. The shamblers will only attack your enemies.</description>
-		<thingClass>Building_TurretGun</thingClass>
+		<thingClass>RimWorldColumns.Building_TurretGunColumn</thingClass>
 		<graphicData>
 			<drawSize>(1.25,1.25)</drawSize>
 			<drawOffset>(0,0,0.2)</drawOffset>

--- a/Source/RimWorldColumns/RimWorldColumns/Building_TurretGunColumn.cs
+++ b/Source/RimWorldColumns/RimWorldColumns/Building_TurretGunColumn.cs
@@ -1,0 +1,18 @@
+using RimWorld;
+using Verse;
+using CombatExtended;
+
+namespace RimWorldColumns
+{
+    public class Building_TurretGunColumn : Building_TurretGun
+    {
+        public override bool ThreatDisabled(Thing other = null)
+        {
+            var compAmmo = this.TryGetComp<CompAmmoUser>();
+            if (compAmmo != null && !compAmmo.HasAmmo)
+                return true;
+
+            return base.ThreatDisabled(other);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Building_TurretGunColumn` class derived from `Building_TurretGun`
- override `ThreatDisabled` to ignore turrets without ammo
- reference the new turret class in weapon column defs for 1.5 and 1.6

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68601e2e0c20832faac0730916f8f1c9