### PR TITLE
Fix threat detection for unfueled turret columns

### DIFF
--- a/Source/RimWorldColumns/RimWorldColumns/HarmonyPatches.cs
+++ b/Source/RimWorldColumns/RimWorldColumns/HarmonyPatches.cs
@@ -99,4 +99,18 @@ namespace RimWorldColumns
             __result += HarmonyPatches.extraColumns.Sum(r.ThingCount);
         }
     }
+
+    [HarmonyPatch(typeof(Building_TurretGun), nameof(Building_TurretGun.ThreatDisabled))]
+    static class Patch_Building_TurretGun_ThreatDisabled
+    {
+        static void Postfix(Building_TurretGun __instance, ref bool __result, IAttackTargetSearcher other)
+        {
+            if (__instance is Building_TurretGunColumn column)
+            {
+                var compAmmo = column.TryGetComp<CompRefuelable>();
+                if (compAmmo != null && !compAmmo.HasFuel)
+                    __result = true;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- revert method hiding on `Building_TurretGunColumn`
- patch `Building_TurretGun.ThreatDisabled` via Harmony so unfueled columns are ignored

## Testing
- ❌ `msbuild` (command not found)
- ❌ `dotnet build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_686022ca77e8832fad9da23ab46399fe